### PR TITLE
Avoid using String

### DIFF
--- a/arduboy_the_horde/FlashStringHelper.h
+++ b/arduboy_the_horde/FlashStringHelper.h
@@ -1,0 +1,67 @@
+#pragma once
+
+//
+// Copyright (C) 2019 Pharap (@Pharap)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Include __FlashStringHelper
+#include <WString.h>
+
+//
+// FlashStringHelper
+//
+
+using FlashStringHelper = const __FlashStringHelper *;
+
+//
+// asFlashStringHelper
+//
+
+inline FlashStringHelper asFlashStringHelper(const char * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(static_cast<const void *>(flashString));
+}
+
+inline FlashStringHelper asFlashStringHelper(const unsigned char * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(static_cast<const void *>(flashString));
+}
+
+inline FlashStringHelper asFlashStringHelper(const signed char * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(static_cast<const void *>(flashString));
+}
+
+// Include pgm_read_ptr
+#include <avr/pgmspace.h>
+
+//
+// readFlashString
+//
+
+inline FlashStringHelper readFlashStringPointer(const char * const * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(pgm_read_ptr(flashString));
+}
+
+inline FlashStringHelper readFlashStringPointer(const unsigned char * const * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(pgm_read_ptr(flashString));
+}
+
+inline FlashStringHelper readFlashStringPointer(const signed char * const * flashString) noexcept
+{
+	return static_cast<FlashStringHelper>(pgm_read_ptr(flashString));
+}

--- a/arduboy_the_horde/Size.h
+++ b/arduboy_the_horde/Size.h
@@ -1,0 +1,51 @@
+#pragma once
+
+//
+// Copyright (C) 2019 Pharap (@Pharap)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if defined(ARDUINO)
+
+// Include size_t
+#include <stddef.h>
+
+#else
+
+// Include std::size_t
+#include <cstddef>
+
+#endif
+
+//
+// getSize
+//
+
+#if defined(ARDUINO)
+
+template< typename Type, size_t size >
+constexpr size_t getSize(const Type (&)[size]) noexcept
+{
+	return size;
+}
+
+#else
+
+template< typename Type, std::size_t size >
+constexpr std::size_t getSize(const Type (&)[size]) noexcept
+{
+	return size;
+}
+
+#endif

--- a/arduboy_the_horde/arduboy_the_horde.ino
+++ b/arduboy_the_horde/arduboy_the_horde.ino
@@ -277,10 +277,12 @@ void drawStatusBar() {
   
   // Draw status bar text
   arduboy.setCursor(1, 1);
-  arduboy.print("W: " + (String)(player.wave - 1));
+  arduboy.print(F("W: "));
+  arduboy.print(player.wave - 1);
   
   arduboy.setCursor(58, 1);
-  arduboy.print("K: " + (String)player.kills);
+  arduboy.print(F("K: "));
+  arduboy.print(player.kills);
   
   // Return text param to normal
   arduboy.setTextSize(current_text_size);
@@ -362,7 +364,10 @@ void spawnEnemy(int count) {
   
     //Serial.println("Generating enemy w/ speed: " + (String)test_enemy.ENEMY_SPEED);
 
-    Serial.println("Spawning enemy -> x: " + (String)test_enemy.x + " y: " + (String)test_enemy.y);
+    Serial.print(F("Spawning enemy -> x: "));
+	Serial.print(test_enemy.x);
+	Serial.print(F(" y: "));
+	Serial.println(test_enemy.y);
   
     enemies.add(test_enemy);
   }
@@ -932,9 +937,19 @@ void loop() {
     arduboy.clear();
 
     //arduboy.println("You Died");
-    arduboy.println("Dead\nWaves : " + (String)(player.wave - 1) +
-                    "\nKills: " + (String)player.kills +
-                    "\nHit&: " + (String)((player.kills * 100) / player.total_shots) + "%");
+    arduboy.print(F("Dead\nWaves : "));
+    arduboy.println(player.wave - 1);
+    arduboy.print(F("Kills: "));
+	arduboy.println(player.kills);
+    arduboy.print(F("Hit&: "));
+    arduboy.print((player.kills * 100) / player.total_shots);
+    arduboy.print(F("%\nDead\nWaves : "));
+	arduboy.println(player.wave - 1);
+    arduboy.print(F("Kills: "));
+	arduboy.println(player.kills);
+    arduboy.print(F("Hit&: "));
+	arduboy.print((player.kills * 100) / player.total_shots);
+    arduboy.print(F("%\n"));
 
     runMenu(&loseMenu);
     


### PR DESCRIPTION
This PR completely removes all use of `String` and replaces it with regular character arrays kept in progmem combined with the `__FlashStringHelper` trick and some template-based size inference.

**Before**
> Sketch uses 17694 bytes (61%) of program storage space. Maximum is 28672 bytes.
Global variables use 1622 bytes (63%) of dynamic memory, leaving 938 bytes for local variables. Maximum is 2560 bytes.

**After**
> Sketch uses 15882 bytes (55%) of program storage space. Maximum is 28672 bytes.
Global variables use 1494 bytes (58%) of dynamic memory, leaving 1066 bytes for local variables. Maximum is 2560 bytes.

**Total Savings**
1812 bytes (6%) of progmem
128 bytes (5%) of RAM

(This is probably the biggest memory saving saving I've ever done in a single PR.)

The moral of the story: don't use Arduino's `String` type for anything serious, especially when you can precompute the strings or rely on `Print`'s `print` and `println` functions to handle the formatting for you.